### PR TITLE
Fix missing remote address in Tang logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ EXPOSE 8080
 VOLUME [ "/db" ]
 
 
-CMD [ "socat", "tcp-l:8080,reuseaddr,fork", "exec:'tangd /db'" ]
+CMD [ "socat", "tcp-l:8080,reuseaddr,fork", "system:'REMOTE_ADDR=$SOCAT_PEERADDR tangd /db'" ]
 
 
 HEALTHCHECK --start-period=5s --interval=30s --timeout=5s --retries=3 \


### PR DESCRIPTION
The HTTP logs from Tang in this container image do not contain the remote IP address.

Example:
```
<unknown> GET /adv/ => 200 (../src/tangd.c:71)
```

Tang [inspects](https://github.com/latchset/tang/blob/e2059ee1109510a7c14b099af7dcd8631e598270/src/http.c#L80-L84) the `REMOTE_ADDR` environment variable (which [normally gets populated](https://www.freedesktop.org/software/systemd/man/systemd.socket.html#Accept=) when using systemd sockets). Since the container doesn't use systemd sockets, the `REMOTE_ADDR` doesn't get populated, and Tang falls back to displaying `<unknown>`.

This PR contains one commit to fix this issue by setting `REMOTE_ADDR` to be equivalent to [SOCAT_PEERADDR](http://www.dest-unreach.org/socat/doc/socat.html#ENV_SOCAT_DEFAULT_LISTEN_IP). Using [`system`](http://www.dest-unreach.org/socat/doc/socat.html#ADDRESS_SYSTEM) instead of [`exec`](http://www.dest-unreach.org/socat/doc/socat.html#ADDRESS_EXEC) is required to support shell commands (setting the environment variable).
