### PR TITLE
Fix health check failure due to missing IPv6 socat binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ CMD [ "socat", "tcp-l:8080,reuseaddr,fork", "system:'REMOTE_ADDR=$SOCAT_PEERADDR
 
 
 HEALTHCHECK --start-period=5s --interval=30s --timeout=5s --retries=3 \
-        CMD ["wget", "--tries", "5", "-qSO", "/dev/null",  "http://localhost:8080/adv"]
+        CMD ["wget", "--tries", "5", "-qSO", "/dev/null",  "http://127.0.0.1:8080/adv"]


### PR DESCRIPTION
The container health check uses `localhost` which sometimes, depending on the parameters used to start the container, resolves to `::1`. Since `socat` does not listen for incoming IPv6 connections [by default](http://www.dest-unreach.org/socat/doc/socat.html#ADDRESS_TCP_LISTEN), the health check fails because no process is listening on `[::1]:8080`. 

We can verify that `socat` is only listening on IPv4 interfaces by running `netstat` inside the container:

```
# netstat -ln
...
Proto    Recv-Q Send-Q   Local Address     Foreign Address         State
tcp        0           0             0.0.0.0:8080        0.0.0.0:*                      LISTEN
...
```

In this PR, we use `127.0.0.1` instead of `localhost` in the health check to prevent the aforementioned failure. Another solution would be to get `socat` to listen on `0.0.0.0:8080` and `[::1]:8080`, but this would [require](https://superuser.com/questions/879498/make-socat-listen-on-both-ipv4-and-ipv6-stacks) two `socat` commands which seems unnecessary.