### PR TITLE
Fix exit codes in health check script

### DIFF
--- a/check-servers.sh
+++ b/check-servers.sh
@@ -1,4 +1,9 @@
 #!/bin/sh -e
 
-[ "$ENABLE_IPv4" = "1" ] && wget -4qSO /dev/null http://127.0.0.1:8080/adv
-[ "$ENABLE_IPv6" = "1" ] && wget -6qSO /dev/null http://[::1]:8080/adv
+if [ "$ENABLE_IPv4" = "1" ]; then
+  wget -4qSO /dev/null http://127.0.0.1:8080/adv
+fi
+
+if [ "$ENABLE_IPv6" = "1" ]; then
+  wget -6qSO /dev/null http://[::1]:8080/adv
+fi

--- a/start-servers.sh
+++ b/start-servers.sh
@@ -2,7 +2,12 @@
 
 TANG="system:'REMOTE_ADDR=\$SOCAT_PEERADDR tangd /db'"
 
-[ "$ENABLE_IPv4" = "1" ] && socat TCP4-LISTEN:8080,reuseaddr,fork "$TANG" &
-[ "$ENABLE_IPv6" = "1" ] && socat TCP6-LISTEN:8080,ipv6only=1,reuseaddr,fork "$TANG" &
+if [ "$ENABLE_IPv4" = "1" ]; then
+  socat TCP4-LISTEN:8080,reuseaddr,fork "$TANG" &
+fi
+
+if [ "$ENABLE_IPv6" = "1" ]; then
+  socat TCP6-LISTEN:8080,ipv6only=1,reuseaddr,fork "$TANG" &
+fi
 
 wait


### PR DESCRIPTION
Before this PR, if `ENABLE_IPv6` is set to `0` (which is [the default](https://github.com/padhi-homelab/docker_tang/blob/05d1164dba9ee589abd146bb7a86c0d2b5f79f8e/Dockerfile#L84)), then the health check script always exits with code `1` (reporting an unhealthy state) regardless of whether the IPv4 check succeeds or not. 

This happens because the check `[ "$ENABLE_IPv6" = "1" ]` is the last command that runs in the script (when `ENABLE_IPv6=0`), and since it evaluates to `false` (i.e., returns exit code `1`), the entire script exits with exit code `1`, indicating a failure.

In this PR, we explicitly use `if` statements (instead of command chaining using `&&`) to prevent this issue in `check-servers.sh`, and we use `if` statements in `start-servers.sh` to maintain consistency among all shell scripts in the repository.